### PR TITLE
Check for boolean options.artifact. Improve error message

### DIFF
--- a/apps/ops/src/commands/rm.ts
+++ b/apps/ops/src/commands/rm.ts
@@ -166,9 +166,11 @@ program
   )
   .action(async (options) => {
     options.artifact = options.artifact || [];
-    if (options.artifact.length === 0) {
+    // When -a param is set without providing artifacts to remove, the value is set to true instead of empty array
+    if (typeof options.artifact === 'boolean') {
       console.log(
-        chalk.yellow("No artifacts to remove specified. Use the '-a' option.")
+        chalk.yellow("No artifacts to remove specified. Use the '-a' option."),
+        chalk.yellow("\nValid artifacts are: " + AllArtifacts.join(", "))
       );
       return;
     }


### PR DESCRIPTION
Currently, when running `yarn run ops rm -a`, the validation is not catching an empty array (`options.artifact.length === 0`), because the value of `options.artifact` is set to `true` by commander.

By checking if `options.artifact` is boolean, one can assume no artifacts were provided.

This PR also improves the error message, by including all valid artifacts that can be passed when calling `yarn run ops rm -a`